### PR TITLE
fix: resolve fnox via mise in env plugin

### DIFF
--- a/hooks/mise_env.lua
+++ b/hooks/mise_env.lua
@@ -2,76 +2,9 @@ local cmd = require("cmd")
 local json = require("json")
 local file = require("file")
 
--- Minimal debug logging (stderr). Enable with MISE_DEBUG=1 or _.fnox-env={debug=true}
-local function truthy(v)
-    if v == nil then
-        return false
-    end
-    if type(v) == "boolean" then
-        return v
-    end
-    v = tostring(v):lower()
-    return v == "1" or v == "true" or v == "yes" or v == "on"
-end
-
-local function debug_enabled(ctx)
-    return truthy(os.getenv("MISE_DEBUG")) or (ctx and ctx.options and truthy(ctx.options.debug))
-end
-
-local function debug_log(ctx, msg)
-    if not debug_enabled(ctx) then
-        return
-    end
-    -- Match mise/vfox debug prefix style
-    local line = "DEBUG [vfox:fnox-env] " .. tostring(msg) .. "\n"
-    if io and io.stderr and io.stderr.write then
-        io.stderr:write(line)
-    else
-        print(line)
-    end
-end
-
-local function dirname(p)
-    if not p or p == "" then
-        return "."
-    end
-    p = p:gsub("/+$", "")
-    local d = p:match("(.+)/[^/]*$") or ""
-    if d == "" then
-        return "/"
-    end
-    return d
-end
-
-local function shell_escape(s)
-    -- POSIX-safe single-quote escaping: ' -> '"'"'
-    if s == nil then
-        return "''"
-    end
-    s = tostring(s)
-    return "'" .. s:gsub("'", [['"'"']]) .. "'"
-end
-
-local function mise_which_fnox(ctx, cwd)
-    local ok, out = pcall(function()
-        return cmd.exec("mise which fnox", {
-            cwd = cwd,
-            env = {
-                -- Avoid recursive env/plugin evaluation
-                MISE_NO_ENV = "1",
-                MISE_NO_HOOKS = "1",
-            }
-        })
-    end)
-    if not ok then
-        return nil
-    end
-    out = tostring(out or ""):gsub("%s+$", "")
-    if out == "" then
-        return nil
-    end
-    return out
-end
+local log = require("fnox_env_log")
+local fs = require("fnox_env_fs")
+local mise = require("fnox_env_mise")
 
 local function find_fnox_config()
     local cwd = os.getenv("PWD") or "."
@@ -90,37 +23,37 @@ function PLUGIN:MiseEnv(ctx)
     local fnox_bin = ctx.options.fnox_bin or "fnox"
     local profile = ctx.options.profile
 
+    -- Debug: show which quoting branch is active
+    log.log(ctx, "platform=" .. (fs.is_windows() and "windows" or "posix"))
+
     local config_path = find_fnox_config()
     if not config_path then
         return {cacheable = true, watch_files = {}, env = {}}
     end
 
-    local config_dir = dirname(config_path)
-    debug_log(ctx, "fnox_config=" .. tostring(config_path))
+    local config_dir = fs.dirname(config_path)
+    log.log(ctx, "fnox_config=" .. tostring(config_path))
 
     -- If fnox isn't global but is managed by mise, resolve it via `mise which fnox`.
     if ctx.options.fnox_bin == nil then
-        local resolved = mise_which_fnox(ctx, config_dir)
+        local resolved = mise.which_fnox(config_dir)
         if resolved then
             fnox_bin = resolved
-            debug_log(ctx, "fnox_bin=" .. tostring(resolved))
+            log.log(ctx, "fnox_bin=" .. tostring(resolved))
         else
-            debug_log(ctx, "fnox_bin=fnox (PATH)")
+            log.log(ctx, "fnox_bin=fnox (PATH)")
         end
     end
 
-    local command = shell_escape(fnox_bin) .. " export --format json"
-    if profile then
-        command = command .. " --profile " .. shell_escape(profile)
-    end
-    debug_log(ctx, "command=" .. command)
+    local command = fs.build_fnox_export_command(fnox_bin, profile)
+    log.log(ctx, "command=" .. command)
 
     local ok, output = pcall(function()
         return cmd.exec(command, {cwd = config_dir})
     end)
 
     if not ok then
-        debug_log(ctx, "fnox exec failed: " .. tostring(output))
+        log.log(ctx, "fnox exec failed: " .. tostring(output))
         return {cacheable = true, watch_files = {config_path}, env = {}}
     end
 

--- a/lib/fnox_env_fs.lua
+++ b/lib/fnox_env_fs.lua
@@ -1,0 +1,57 @@
+-- Filesystem/path helpers for fnox-env.
+
+local file = require("file")
+
+local M = {}
+
+function M.dirname(p)
+    if not p or p == "" then
+        return "."
+    end
+    p = p:gsub("/+$", "")
+    local d = p:match("(.+)/[^/]*$") or ""
+    if d == "" then
+        return "/"
+    end
+    return d
+end
+
+function M.is_windows()
+    return package and package.config and package.config:sub(1, 1) == "\\"
+end
+
+local function posix_shell_escape(s)
+    -- POSIX-safe single-quote escaping: ' -> '"'"'
+    if s == nil then
+        return "''"
+    end
+    s = tostring(s)
+    return "'" .. s:gsub("'", [['"'"']]) .. "'"
+end
+
+local function win_quote_arg(s)
+    -- cmd.exe quoting for a single argument
+    s = tostring(s)
+    return '"' .. s:gsub('"', '""') .. '"'
+end
+
+function M.build_fnox_export_command(fnox_bin, profile)
+    -- On Windows, do NOT quote the executable path because cmd.exec/cmd.exe can treat
+    -- quote characters literally after internal escaping. Quote only arguments.
+    if M.is_windows() then
+        local cmdline = tostring(fnox_bin) .. " export --format json"
+        if profile then
+            cmdline = cmdline .. " --profile " .. win_quote_arg(profile)
+        end
+        return cmdline
+    end
+
+    local cmdline = posix_shell_escape(fnox_bin) .. " export --format json"
+    if profile then
+        cmdline = cmdline .. " --profile " .. posix_shell_escape(profile)
+    end
+    return cmdline
+end
+
+return M
+

--- a/lib/fnox_env_log.lua
+++ b/lib/fnox_env_log.lua
@@ -1,0 +1,33 @@
+-- Lightweight debug logging helpers for fnox-env.
+
+local M = {}
+
+local function truthy(v)
+    if v == nil then
+        return false
+    end
+    if type(v) == "boolean" then
+        return v
+    end
+    v = tostring(v):lower()
+    return v == "1" or v == "true" or v == "yes" or v == "on"
+end
+
+function M.enabled(ctx)
+    return truthy(os.getenv("MISE_DEBUG")) or (ctx and ctx.options and truthy(ctx.options.debug))
+end
+
+function M.log(ctx, msg)
+    if not M.enabled(ctx) then
+        return
+    end
+    local line = "DEBUG [vfox:fnox-env] " .. tostring(msg) .. "\n"
+    if io and io.stderr and io.stderr.write then
+        io.stderr:write(line)
+    else
+        print(line)
+    end
+end
+
+return M
+

--- a/lib/fnox_env_mise.lua
+++ b/lib/fnox_env_mise.lua
@@ -1,0 +1,29 @@
+-- mise integration helpers for fnox-env.
+
+local cmd = require("cmd")
+
+local M = {}
+
+function M.which_fnox(cwd)
+    local ok, out = pcall(function()
+        return cmd.exec("mise which fnox", {
+            cwd = cwd,
+            env = {
+                -- Avoid recursive env/plugin evaluation
+                MISE_NO_ENV = "1",
+                MISE_NO_HOOKS = "1",
+            }
+        })
+    end)
+    if not ok then
+        return nil
+    end
+    out = tostring(out or ""):gsub("%s+$", "")
+    if out == "" then
+        return nil
+    end
+    return out
+end
+
+return M
+


### PR DESCRIPTION
Use `mise which fnox` to find the mise-managed fnox binary when fnox is not global, and run export from the directory containing fnox.toml. Adds minimal debug logs under MISE_DEBUG.