### PR TITLE
feat: include lease credentials in env export

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ _.fnox-env = { tools = true }
 
 ## Configuration Options
 
-| Option     | Description                                      | Default   |
-| ---------- | ------------------------------------------------ | --------- |
-| `tools`    | Use mise-managed tools (required if fnox is installed via mise) | `false`   |
-| `profile`  | fnox profile to use                              | `default` |
-| `fnox_bin` | Path to fnox binary                              | `fnox`    |
+| Option            | Description                                                          | Default   |
+| ----------------- | -------------------------------------------------------------------- | --------- |
+| `tools`           | Use mise-managed tools (required if fnox is installed via mise)      | `false`   |
+| `profile`         | fnox profile to use                                                  | `default` |
+| `fnox_bin`        | Path to fnox binary                                                  | `fnox`    |
+| `leases`          | Run `fnox lease create --all` on activation (requires `[leases.*]`)  | `false`   |
+| `export_timeout`  | Seconds before `fnox export` is killed                               | `15`      |
+| `lease_timeout`   | Seconds before `fnox lease create` is killed                         | `30`      |
 
 ### Examples
 

--- a/hooks/mise_env.lua
+++ b/hooks/mise_env.lua
@@ -3,10 +3,13 @@ local json = require("json")
 
 local function resolve_fnox_bin(fnox_bin)
     local home = os.getenv("HOME") or os.getenv("USERPROFILE") or ""
+    -- Prefer the shim (which respects mise's version resolution, honoring
+    -- project-level pins) over `installs/latest` (managed by mise's default
+    -- alias — wrong when the user has pinned to a non-latest version).
     local candidates = {
         fnox_bin,
-        home .. "/.local/share/mise/installs/fnox/latest/fnox",
         home .. "/.local/share/mise/shims/fnox",
+        home .. "/.local/share/mise/installs/fnox/latest/fnox",
     }
     for _, path in ipairs(candidates) do
         local f = io.open(path, "r")

--- a/hooks/mise_env.lua
+++ b/hooks/mise_env.lua
@@ -25,11 +25,26 @@ local function exec(command, opts)
     return ok, output
 end
 
-local function get_config_files(fnox_bin, opts)
-    local ok, output = exec(fnox_bin .. " config-files", opts)
+local function run_json(command, opts)
+    local ok, output = exec(command, opts)
     if not ok then
-        print("[fnox] warning: `" .. fnox_bin .. " config-files` failed: " .. tostring(output))
-        return {}
+        error("[fnox] `" .. command .. "` failed: " .. tostring(output))
+    end
+    if not output or output == "" then
+        error("[fnox] `" .. command .. "` returned empty output")
+    end
+    local decode_ok, data = pcall(json.decode, output)
+    if not decode_ok then
+        error("[fnox] failed to parse JSON from `" .. command .. "`: " .. tostring(data))
+    end
+    return data
+end
+
+local function get_config_files(fnox_bin, opts)
+    local command = fnox_bin .. " config-files"
+    local ok, output = exec(command, opts)
+    if not ok then
+        error("[fnox] `" .. command .. "` failed: " .. tostring(output))
     end
     if not output or output == "" then
         return {}
@@ -39,6 +54,20 @@ local function get_config_files(fnox_bin, opts)
         table.insert(files, line)
     end
     return files
+end
+
+local function has_lease_backends(config_files)
+    for _, path in ipairs(config_files) do
+        local f = io.open(path, "r")
+        if f then
+            local content = f:read("*a")
+            f:close()
+            if content and (content:match("%[leases%.") or content:match("%[%[leases")) then
+                return true
+            end
+        end
+    end
+    return false
 end
 
 function PLUGIN:MiseEnv(ctx)
@@ -67,33 +96,19 @@ function PLUGIN:MiseEnv(ctx)
 
     -- export secrets
     local export_cmd = fnox_bin .. " export --format json" .. profile_flag
-    local ok, output = exec(export_cmd, exec_opts)
-    if ok then
-        local decode_ok, data = pcall(json.decode, output)
-        if decode_ok then
-            for key, value in pairs(data.secrets or {}) do
-                table.insert(env_vars, {key = key, value = value})
-            end
-        else
-            print("[fnox] warning: failed to parse JSON from `" .. export_cmd .. "`: " .. tostring(data))
-        end
-    else
-        print("[fnox] warning: `" .. export_cmd .. "` failed: " .. tostring(output))
+    local data = run_json(export_cmd, exec_opts)
+    for key, value in pairs(data.secrets or {}) do
+        table.insert(env_vars, {key = key, value = value})
     end
 
-    -- create leases and merge credentials
-    local lease_cmd = fnox_bin .. " lease create --all --format json" .. profile_flag
-    local lok, loutput = exec(lease_cmd, exec_opts)
-    if lok then
-        local ldecode_ok, ldata = pcall(json.decode, loutput)
-        if ldecode_ok then
-            for key, value in pairs(ldata) do
-                if key ~= "backend" and key ~= "lease_id" and type(value) == "string" then
-                    table.insert(env_vars, {key = key, value = value})
-                end
+    -- create leases (only if any backends are configured)
+    if has_lease_backends(config_files) then
+        local lease_cmd = fnox_bin .. " lease create --all --format json" .. profile_flag
+        local ldata = run_json(lease_cmd, exec_opts)
+        for key, value in pairs(ldata) do
+            if key ~= "backend" and key ~= "lease_id" and type(value) == "string" then
+                table.insert(env_vars, {key = key, value = value})
             end
-        else
-            print("[fnox] warning: failed to parse JSON from `" .. lease_cmd .. "`: " .. tostring(ldata))
         end
     end
 

--- a/hooks/mise_env.lua
+++ b/hooks/mise_env.lua
@@ -31,7 +31,7 @@ local function run_json(command, opts)
         error("[fnox] `" .. command .. "` failed: " .. tostring(output))
     end
     if not output or output == "" then
-        error("[fnox] `" .. command .. "` returned empty output")
+        return {}
     end
     local decode_ok, data = pcall(json.decode, output)
     if not decode_ok then
@@ -44,7 +44,8 @@ local function get_config_files(fnox_bin, opts)
     local command = fnox_bin .. " config-files"
     local ok, output = exec(command, opts)
     if not ok then
-        error("[fnox] `" .. command .. "` failed: " .. tostring(output))
+        print("[fnox] warning: `" .. command .. "` failed: " .. tostring(output))
+        return nil
     end
     if not output or output == "" then
         return {}
@@ -83,6 +84,11 @@ function PLUGIN:MiseEnv(ctx)
     end
 
     local config_files = get_config_files(fnox_bin, exec_opts)
+    if not config_files then
+        -- config-files failed; return a non-cacheable empty result so mise
+        -- proceeds and retries on the next activation
+        return {cacheable = false, watch_files = {}, env = {}}
+    end
     if #config_files == 0 then
         return {cacheable = true, watch_files = {}, env = {}}
     end
@@ -93,27 +99,41 @@ function PLUGIN:MiseEnv(ctx)
     end
 
     local env_vars = {}
+    local had_failure = false
 
-    -- export secrets
+    -- export secrets: failures are surfaced as warnings, not errors, so a
+    -- broken fnox invocation never blocks mise from progressing
     local export_cmd = fnox_bin .. " export --format json" .. profile_flag
-    local data = run_json(export_cmd, exec_opts)
-    for key, value in pairs(data.secrets or {}) do
-        table.insert(env_vars, {key = key, value = value})
+    local eok, edata = pcall(run_json, export_cmd, exec_opts)
+    if eok then
+        for key, value in pairs(edata.secrets or {}) do
+            table.insert(env_vars, {key = key, value = value})
+        end
+    else
+        had_failure = true
+        print("[fnox] warning: export failed, continuing without secrets: " .. tostring(edata))
     end
 
-    -- create leases (only if any backends are configured)
+    -- create leases (only if any backends are configured); same policy as
+    -- export — warn on failure, never block mise
     if has_lease_backends(config_files) then
         local lease_cmd = fnox_bin .. " lease create --all --format json" .. profile_flag
-        local ldata = run_json(lease_cmd, exec_opts)
-        for key, value in pairs(ldata) do
-            if key ~= "backend" and key ~= "lease_id" and type(value) == "string" then
-                table.insert(env_vars, {key = key, value = value})
+        local lok, ldata = pcall(run_json, lease_cmd, exec_opts)
+        if lok then
+            for key, value in pairs(ldata) do
+                if key ~= "backend" and key ~= "lease_id" and type(value) == "string" then
+                    table.insert(env_vars, {key = key, value = value})
+                end
             end
+        else
+            had_failure = true
+            print("[fnox] warning: lease creation failed, continuing without lease credentials: " .. tostring(ldata))
         end
     end
 
     return {
-        cacheable = true,
+        -- don't cache partial results so mise retries after a transient failure
+        cacheable = not had_failure,
         watch_files = config_files,
         env = env_vars,
         redact = true

--- a/hooks/mise_env.lua
+++ b/hooks/mise_env.lua
@@ -18,6 +18,11 @@ local function resolve_fnox_bin(fnox_bin)
     return fnox_bin
 end
 
+local function strip_traceback(msg)
+    if not msg then return "" end
+    return (tostring(msg):gsub("\r?\n%s*stack traceback:.*$", ""))
+end
+
 local function exec(command, opts)
     local ok, output = pcall(function()
         return cmd.exec(command, opts)
@@ -44,7 +49,7 @@ local function get_config_files(fnox_bin, opts)
     local command = fnox_bin .. " config-files"
     local ok, output = exec(command, opts)
     if not ok then
-        print("[fnox] warning: `" .. command .. "` failed: " .. tostring(output))
+        print("[fnox] warning: `" .. command .. "` failed: " .. strip_traceback(output))
         return nil
     end
     if not output or output == "" then
@@ -111,7 +116,7 @@ function PLUGIN:MiseEnv(ctx)
         end
     else
         had_failure = true
-        print("[fnox] warning: export failed, continuing without secrets: " .. tostring(edata))
+        print("[fnox] warning: export failed, continuing without secrets: " .. strip_traceback(edata))
     end
 
     -- create leases (only if any backends are configured); same policy as
@@ -127,7 +132,7 @@ function PLUGIN:MiseEnv(ctx)
             end
         else
             had_failure = true
-            print("[fnox] warning: lease creation failed, continuing without lease credentials: " .. tostring(ldata))
+            print("[fnox] warning: lease creation failed, continuing without lease credentials: " .. strip_traceback(ldata))
         end
     end
 

--- a/hooks/mise_env.lua
+++ b/hooks/mise_env.lua
@@ -64,6 +64,42 @@ local function run_json(command)
     return data
 end
 
+-- Run a fnox subcommand that emits JSON. On failure, prints a warning
+-- naming `label` and returns nil so the caller can flag had_failure but
+-- keep going. Never throws.
+local function fetch_json(label, fnox_bin, args, timeout_secs)
+    local command = build_command(fnox_bin, args, timeout_secs)
+    local ok, data = pcall(run_json, command)
+    if not ok then
+        print("[fnox] warning: " .. label .. " failed, continuing: " .. strip_traceback(data))
+        return nil
+    end
+    return data
+end
+
+-- Merge a {key=value} map into env_vars, replacing any prior entry with
+-- the same key. Warns on collision when source_label is set.
+local function merge_creds(env_vars, seen, creds, source_label)
+    for key, value in pairs(creds) do
+        if seen[key] and source_label then
+            print("[fnox] warning: " .. source_label
+                .. " credential `" .. key .. "` overrides earlier value")
+        end
+        local replaced = false
+        for i, entry in ipairs(env_vars) do
+            if entry.key == key then
+                env_vars[i] = {key = key, value = value}
+                replaced = true
+                break
+            end
+        end
+        if not replaced then
+            table.insert(env_vars, {key = key, value = value})
+        end
+        seen[key] = true
+    end
+end
+
 local function get_config_files(fnox_bin)
     local command = build_command(fnox_bin, "config-files", 5)
     local ok, output = exec(command)
@@ -100,6 +136,18 @@ local function has_lease_backends(config_files)
     return false
 end
 
+-- Strip lease metadata keys and keep only string values, then return a
+-- plain {key=value} map suitable for merge_creds.
+local function lease_creds(ldata)
+    local out = {}
+    for key, value in pairs(ldata) do
+        if key ~= "backend" and key ~= "lease_id" and type(value) == "string" then
+            out[key] = value
+        end
+    end
+    return out
+end
+
 function PLUGIN:MiseEnv(ctx)
     local fnox_bin = ctx.options.fnox_bin or "fnox"
     local profile = ctx.options.profile
@@ -125,47 +173,23 @@ function PLUGIN:MiseEnv(ctx)
     local seen = {}
     local had_failure = false
 
-    -- export secrets: failures are surfaced as warnings, not errors, so a
-    -- broken fnox invocation never blocks mise from progressing
-    local export_cmd = build_command(fnox_bin, "export --format json" .. profile_args, export_timeout)
-    local eok, edata = pcall(run_json, export_cmd)
-    if eok then
-        for key, value in pairs(edata.secrets or {}) do
-            if not seen[key] then
-                seen[key] = true
-                table.insert(env_vars, {key = key, value = value})
-            end
-        end
+    -- export secrets
+    local edata = fetch_json("export", fnox_bin,
+        "export --format json" .. profile_args, export_timeout)
+    if edata then
+        merge_creds(env_vars, seen, edata.secrets or {}, nil)
     else
         had_failure = true
-        print("[fnox] warning: export failed, continuing without secrets: " .. strip_traceback(edata))
     end
 
-    -- create leases (only if any backends are configured); same policy as
-    -- export -- warn on failure, never block mise
+    -- create leases (only if any backends are configured)
     if has_lease_backends(config_files) then
-        local lease_cmd = build_command(fnox_bin, "lease create --all --format json" .. profile_args, lease_timeout)
-        local lok, ldata = pcall(run_json, lease_cmd)
-        if lok then
-            for key, value in pairs(ldata) do
-                if key ~= "backend" and key ~= "lease_id" and type(value) == "string" then
-                    if seen[key] then
-                        print("[fnox] warning: lease credential `" .. key .. "` overrides exported secret")
-                        for i, entry in ipairs(env_vars) do
-                            if entry.key == key then
-                                env_vars[i] = {key = key, value = value}
-                                break
-                            end
-                        end
-                    else
-                        seen[key] = true
-                        table.insert(env_vars, {key = key, value = value})
-                    end
-                end
-            end
+        local ldata = fetch_json("lease creation", fnox_bin,
+            "lease create --all --format json" .. profile_args, lease_timeout)
+        if ldata then
+            merge_creds(env_vars, seen, lease_creds(ldata), "lease")
         else
             had_failure = true
-            print("[fnox] warning: lease creation failed, continuing without lease credentials: " .. strip_traceback(ldata))
         end
     end
 

--- a/hooks/mise_env.lua
+++ b/hooks/mise_env.lua
@@ -28,31 +28,47 @@ function PLUGIN:MiseEnv(ctx)
         return {cacheable = true, watch_files = {}, env = {}}
     end
 
-    local command = fnox_bin .. " export --format json"
+    local profile_flag = ""
     if profile then
-        command = command .. " --profile " .. profile
+        profile_flag = " --profile " .. profile
     end
-
-    local ok, output = pcall(function()
-        return cmd.exec(command)
-    end)
-
-    if not ok then
-        print("[fnox] warning: `" .. command .. "` failed: " .. tostring(output))
-        return {cacheable = true, watch_files = config_files, env = {}}
-    end
-
-    local decode_ok, data = pcall(json.decode, output)
-    if not decode_ok then
-        print("[fnox] warning: failed to parse JSON from `" .. command .. "`: " .. tostring(data))
-        return {cacheable = true, watch_files = config_files, env = {}}
-    end
-
-    local secrets = data.secrets or {}
 
     local env_vars = {}
-    for key, value in pairs(secrets) do
-        table.insert(env_vars, {key = key, value = value})
+
+    -- export secrets
+    local export_cmd = fnox_bin .. " export --format json" .. profile_flag
+    local ok, output = pcall(function()
+        return cmd.exec(export_cmd)
+    end)
+    if ok then
+        local decode_ok, data = pcall(json.decode, output)
+        if decode_ok then
+            for key, value in pairs(data.secrets or {}) do
+                table.insert(env_vars, {key = key, value = value})
+            end
+        else
+            print("[fnox] warning: failed to parse JSON from `" .. export_cmd .. "`: " .. tostring(data))
+        end
+    else
+        print("[fnox] warning: `" .. export_cmd .. "` failed: " .. tostring(output))
+    end
+
+    -- create leases and merge credentials
+    local lease_cmd = fnox_bin .. " lease create --all --format json" .. profile_flag
+    local lok, loutput = pcall(function()
+        return cmd.exec(lease_cmd)
+    end)
+    if lok then
+        local ldecode_ok, ldata = pcall(json.decode, loutput)
+        if ldecode_ok then
+            for key, value in pairs(ldata) do
+                if key ~= "backend" and key ~= "lease_id" and type(value) == "string" then
+                    table.insert(env_vars, {key = key, value = value})
+                end
+            end
+        else
+            print("[fnox] warning: failed to parse JSON from `" .. lease_cmd .. "`: " .. tostring(ldata))
+        end
     end
 
     return {

--- a/hooks/mise_env.lua
+++ b/hooks/mise_env.lua
@@ -1,15 +1,14 @@
 local cmd = require("cmd")
 local json = require("json")
 
+-- Resolve a usable fnox path when mise's `tools = true` PATH injection
+-- doesn't reach the lua subprocess (a bug in mise 2026.4.6+).
 local function resolve_fnox_bin(fnox_bin)
     local home = os.getenv("HOME") or os.getenv("USERPROFILE") or ""
-    -- Prefer the shim (which respects mise's version resolution, honoring
-    -- project-level pins) over `installs/latest` (managed by mise's default
-    -- alias — wrong when the user has pinned to a non-latest version).
     local candidates = {
         fnox_bin,
-        home .. "/.local/share/mise/shims/fnox",
         home .. "/.local/share/mise/installs/fnox/latest/fnox",
+        home .. "/.local/share/mise/shims/fnox",
     }
     for _, path in ipairs(candidates) do
         local f = io.open(path, "r")
@@ -26,15 +25,58 @@ local function strip_traceback(msg)
     return (tostring(msg):gsub("\r?\n%s*stack traceback:.*$", ""))
 end
 
-local function exec(command, opts)
+local function shquote(s)
+    return "'" .. tostring(s):gsub("'", [['\'']]) .. "'"
+end
+
+-- Detect a `timeout` binary once per activation. Returns the binary name
+-- or nil if none is on PATH.
+local _timeout_bin_cached = nil
+local _timeout_bin_done = false
+local function timeout_bin()
+    if _timeout_bin_done then return _timeout_bin_cached end
+    _timeout_bin_done = true
+    for _, b in ipairs({"timeout", "gtimeout"}) do
+        local f = io.popen("command -v " .. b .. " 2>/dev/null")
+        if f then
+            local out = f:read("*a") or ""
+            f:close()
+            if out:match("%S") then
+                _timeout_bin_cached = b
+                return b
+            end
+        end
+    end
+    return nil
+end
+
+-- Build a shell command string that:
+--   1. Prepends fnox's parent dir to PATH (without replacing the rest of env)
+--   2. Wraps in `timeout` if available so a stalled network call can't hang
+--      mise activation indefinitely.
+local function build_command(fnox_bin, args, timeout_secs)
+    local fnox_dir = fnox_bin:match("(.+)/[^/]+$")
+    local prefix = ""
+    if fnox_dir then
+        prefix = "PATH=" .. shquote(fnox_dir) .. ':"$PATH" '
+    end
+    local body = shquote(fnox_bin) .. " " .. args
+    local tbin = timeout_bin()
+    if tbin and timeout_secs then
+        body = tbin .. " --preserve-status " .. timeout_secs .. " " .. body
+    end
+    return prefix .. body
+end
+
+local function exec(command)
     local ok, output = pcall(function()
-        return cmd.exec(command, opts)
+        return cmd.exec(command)
     end)
     return ok, output
 end
 
-local function run_json(command, opts)
-    local ok, output = exec(command, opts)
+local function run_json(command)
+    local ok, output = exec(command)
     if not ok then
         error("[fnox] `" .. command .. "` failed: " .. tostring(output))
     end
@@ -48,9 +90,9 @@ local function run_json(command, opts)
     return data
 end
 
-local function get_config_files(fnox_bin, opts)
-    local command = fnox_bin .. " config-files"
-    local ok, output = exec(command, opts)
+local function get_config_files(fnox_bin)
+    local command = build_command(fnox_bin, "config-files", 5)
+    local ok, output = exec(command)
     if not ok then
         print("[fnox] warning: `" .. command .. "` failed: " .. strip_traceback(output))
         return nil
@@ -65,13 +107,18 @@ local function get_config_files(fnox_bin, opts)
     return files
 end
 
+-- TOML section headers must start at column 0. Anchor the pattern so
+-- `[leases.x]` inside a comment or multi-line string can't false-positive.
 local function has_lease_backends(config_files)
     for _, path in ipairs(config_files) do
         local f = io.open(path, "r")
         if f then
             local content = f:read("*a")
             f:close()
-            if content and (content:match("%[leases%.") or content:match("%[%[leases")) then
+            if content and (content:match("\n%s*%[leases%.")
+                         or content:match("^%s*%[leases%.")
+                         or content:match("\n%s*%[%[leases")
+                         or content:match("^%s*%[%[leases")) then
                 return true
             end
         end
@@ -82,16 +129,10 @@ end
 function PLUGIN:MiseEnv(ctx)
     local fnox_bin = resolve_fnox_bin(ctx.options.fnox_bin or "fnox")
     local profile = ctx.options.profile
+    local export_timeout = tonumber(ctx.options.export_timeout) or 15
+    local lease_timeout = tonumber(ctx.options.lease_timeout) or 30
 
-    -- ensure fnox's parent dir is on PATH for subprocesses
-    local fnox_dir = fnox_bin:match("(.+)/[^/]+$")
-    local exec_opts = {}
-    if fnox_dir then
-        local path = os.getenv("PATH") or ""
-        exec_opts = {env = {PATH = fnox_dir .. ":" .. path}}
-    end
-
-    local config_files = get_config_files(fnox_bin, exec_opts)
+    local config_files = get_config_files(fnox_bin)
     if not config_files then
         -- config-files failed; return a non-cacheable empty result so mise
         -- proceeds and retries on the next activation
@@ -101,21 +142,25 @@ function PLUGIN:MiseEnv(ctx)
         return {cacheable = true, watch_files = {}, env = {}}
     end
 
-    local profile_flag = ""
+    local profile_args = ""
     if profile then
-        profile_flag = " --profile " .. profile
+        profile_args = " --profile " .. shquote(profile)
     end
 
     local env_vars = {}
+    local seen = {}
     local had_failure = false
 
     -- export secrets: failures are surfaced as warnings, not errors, so a
     -- broken fnox invocation never blocks mise from progressing
-    local export_cmd = fnox_bin .. " export --format json" .. profile_flag
-    local eok, edata = pcall(run_json, export_cmd, exec_opts)
+    local export_cmd = build_command(fnox_bin, "export --format json" .. profile_args, export_timeout)
+    local eok, edata = pcall(run_json, export_cmd)
     if eok then
         for key, value in pairs(edata.secrets or {}) do
-            table.insert(env_vars, {key = key, value = value})
+            if not seen[key] then
+                seen[key] = true
+                table.insert(env_vars, {key = key, value = value})
+            end
         end
     else
         had_failure = true
@@ -123,14 +168,25 @@ function PLUGIN:MiseEnv(ctx)
     end
 
     -- create leases (only if any backends are configured); same policy as
-    -- export — warn on failure, never block mise
+    -- export -- warn on failure, never block mise
     if has_lease_backends(config_files) then
-        local lease_cmd = fnox_bin .. " lease create --all --format json" .. profile_flag
-        local lok, ldata = pcall(run_json, lease_cmd, exec_opts)
+        local lease_cmd = build_command(fnox_bin, "lease create --all --format json" .. profile_args, lease_timeout)
+        local lok, ldata = pcall(run_json, lease_cmd)
         if lok then
             for key, value in pairs(ldata) do
                 if key ~= "backend" and key ~= "lease_id" and type(value) == "string" then
-                    table.insert(env_vars, {key = key, value = value})
+                    if seen[key] then
+                        print("[fnox] warning: lease credential `" .. key .. "` overrides exported secret")
+                        for i, entry in ipairs(env_vars) do
+                            if entry.key == key then
+                                env_vars[i] = {key = key, value = value}
+                                break
+                            end
+                        end
+                    else
+                        seen[key] = true
+                        table.insert(env_vars, {key = key, value = value})
+                    end
                 end
             end
         else

--- a/hooks/mise_env.lua
+++ b/hooks/mise_env.lua
@@ -64,17 +64,18 @@ local function run_json(command)
     return data
 end
 
--- Run a fnox subcommand that emits JSON. On failure, prints a warning
--- naming `label` and returns nil so the caller can flag had_failure but
--- keep going. Never throws.
-local function fetch_json(label, fnox_bin, args, timeout_secs)
+-- Run a fnox subcommand that emits JSON. Returns (data, err) where err is
+-- non-nil only on an unexpected failure (the warning has already been
+-- printed in that case). If `ignore_re` matches the failure message, the
+-- error is treated as an expected no-op: returns (nil, nil) silently.
+local function fetch_json(label, fnox_bin, args, timeout_secs, ignore_re)
     local command = build_command(fnox_bin, args, timeout_secs)
     local ok, data = pcall(run_json, command)
-    if not ok then
-        print("[fnox] warning: " .. label .. " failed, continuing: " .. strip_traceback(data))
-        return nil
-    end
-    return data
+    if ok then return data, nil end
+    local msg = strip_traceback(tostring(data))
+    if ignore_re and msg:find(ignore_re) then return nil, nil end
+    print("[fnox] warning: " .. label .. " failed, continuing: " .. msg)
+    return nil, msg
 end
 
 -- Merge a {key=value} map into env_vars, replacing any prior entry with
@@ -117,25 +118,6 @@ local function get_config_files(fnox_bin)
     return files
 end
 
--- TOML section headers must start at column 0. Anchor the pattern so
--- `[leases.x]` inside a comment or multi-line string can't false-positive.
-local function has_lease_backends(config_files)
-    for _, path in ipairs(config_files) do
-        local f = io.open(path, "r")
-        if f then
-            local content = f:read("*a")
-            f:close()
-            if content and (content:match("\n%s*%[leases%.")
-                         or content:match("^%s*%[leases%.")
-                         or content:match("\n%s*%[%[leases")
-                         or content:match("^%s*%[%[leases")) then
-                return true
-            end
-        end
-    end
-    return false
-end
-
 -- Strip lease metadata keys and keep only string values, then return a
 -- plain {key=value} map suitable for merge_creds.
 local function lease_creds(ldata)
@@ -174,24 +156,18 @@ function PLUGIN:MiseEnv(ctx)
     local had_failure = false
 
     -- export secrets
-    local edata = fetch_json("export", fnox_bin,
+    local edata, eerr = fetch_json("export", fnox_bin,
         "export --format json" .. profile_args, export_timeout)
-    if edata then
-        merge_creds(env_vars, seen, edata.secrets or {}, nil)
-    else
-        had_failure = true
-    end
+    if edata then merge_creds(env_vars, seen, edata.secrets or {}, nil) end
+    if eerr then had_failure = true end
 
-    -- create leases (only if any backends are configured)
-    if has_lease_backends(config_files) then
-        local ldata = fetch_json("lease creation", fnox_bin,
-            "lease create --all --format json" .. profile_args, lease_timeout)
-        if ldata then
-            merge_creds(env_vars, seen, lease_creds(ldata), "lease")
-        else
-            had_failure = true
-        end
-    end
+    -- create leases. Silently skip when no [leases.*] backends are
+    -- configured (fnox returns a specific config error in that case).
+    local ldata, lerr = fetch_json("lease creation", fnox_bin,
+        "lease create --all --format json" .. profile_args, lease_timeout,
+        "No lease backends configured")
+    if ldata then merge_creds(env_vars, seen, lease_creds(ldata), "lease") end
+    if lerr then had_failure = true end
 
     return {
         -- don't cache partial results so mise retries after a transient failure

--- a/hooks/mise_env.lua
+++ b/hooks/mise_env.lua
@@ -65,15 +65,13 @@ local function run_json(command)
 end
 
 -- Run a fnox subcommand that emits JSON. Returns (data, err) where err is
--- non-nil only on an unexpected failure (the warning has already been
--- printed in that case). If `ignore_re` matches the failure message, the
--- error is treated as an expected no-op: returns (nil, nil) silently.
-local function fetch_json(label, fnox_bin, args, timeout_secs, ignore_re)
+-- non-nil only on failure (the warning has already been printed in that
+-- case). Never throws.
+local function fetch_json(label, fnox_bin, args, timeout_secs)
     local command = build_command(fnox_bin, args, timeout_secs)
     local ok, data = pcall(run_json, command)
     if ok then return data, nil end
     local msg = strip_traceback(tostring(data))
-    if ignore_re and msg:find(ignore_re) then return nil, nil end
     print("[fnox] warning: " .. label .. " failed, continuing: " .. msg)
     return nil, msg
 end
@@ -133,6 +131,9 @@ end
 function PLUGIN:MiseEnv(ctx)
     local fnox_bin = ctx.options.fnox_bin or "fnox"
     local profile = ctx.options.profile
+    -- opt-in: `leases = true` to run `fnox lease create --all` on activation.
+    -- Off by default so users without [leases.*] backends don't see warnings.
+    local leases_enabled = ctx.options.leases == true or ctx.options.leases == "true"
     local export_timeout = tonumber(ctx.options.export_timeout) or 15
     local lease_timeout = tonumber(ctx.options.lease_timeout) or 30
 
@@ -161,13 +162,13 @@ function PLUGIN:MiseEnv(ctx)
     if edata then merge_creds(env_vars, seen, edata.secrets or {}, nil) end
     if eerr then had_failure = true end
 
-    -- create leases. Silently skip when no [leases.*] backends are
-    -- configured (fnox returns a specific config error in that case).
-    local ldata, lerr = fetch_json("lease creation", fnox_bin,
-        "lease create --all --format json" .. profile_args, lease_timeout,
-        "No lease backends configured")
-    if ldata then merge_creds(env_vars, seen, lease_creds(ldata), "lease") end
-    if lerr then had_failure = true end
+    -- create leases (opt-in via `leases = true` plugin option)
+    if leases_enabled then
+        local ldata, lerr = fetch_json("lease creation", fnox_bin,
+            "lease create --all --format json" .. profile_args, lease_timeout)
+        if ldata then merge_creds(env_vars, seen, lease_creds(ldata), "lease") end
+        if lerr then had_failure = true end
+    end
 
     return {
         -- don't cache partial results so mise retries after a transient failure

--- a/hooks/mise_env.lua
+++ b/hooks/mise_env.lua
@@ -1,25 +1,6 @@
 local cmd = require("cmd")
 local json = require("json")
 
--- Resolve a usable fnox path when mise's `tools = true` PATH injection
--- doesn't reach the lua subprocess (a bug in mise 2026.4.6+).
-local function resolve_fnox_bin(fnox_bin)
-    local home = os.getenv("HOME") or os.getenv("USERPROFILE") or ""
-    local candidates = {
-        fnox_bin,
-        home .. "/.local/share/mise/installs/fnox/latest/fnox",
-        home .. "/.local/share/mise/shims/fnox",
-    }
-    for _, path in ipairs(candidates) do
-        local f = io.open(path, "r")
-        if f then
-            f:close()
-            return path
-        end
-    end
-    return fnox_bin
-end
-
 local function strip_traceback(msg)
     if not msg then return "" end
     return (tostring(msg):gsub("\r?\n%s*stack traceback:.*$", ""))
@@ -50,22 +31,15 @@ local function timeout_bin()
     return nil
 end
 
--- Build a shell command string that:
---   1. Prepends fnox's parent dir to PATH (without replacing the rest of env)
---   2. Wraps in `timeout` if available so a stalled network call can't hang
---      mise activation indefinitely.
+-- Build a shell command, wrapped in `timeout` if available so a stalled
+-- network call can't hang mise activation indefinitely.
 local function build_command(fnox_bin, args, timeout_secs)
-    local fnox_dir = fnox_bin:match("(.+)/[^/]+$")
-    local prefix = ""
-    if fnox_dir then
-        prefix = "PATH=" .. shquote(fnox_dir) .. ':"$PATH" '
-    end
     local body = shquote(fnox_bin) .. " " .. args
     local tbin = timeout_bin()
     if tbin and timeout_secs then
         body = tbin .. " --preserve-status " .. timeout_secs .. " " .. body
     end
-    return prefix .. body
+    return body
 end
 
 local function exec(command)
@@ -127,7 +101,7 @@ local function has_lease_backends(config_files)
 end
 
 function PLUGIN:MiseEnv(ctx)
-    local fnox_bin = resolve_fnox_bin(ctx.options.fnox_bin or "fnox")
+    local fnox_bin = ctx.options.fnox_bin or "fnox"
     local profile = ctx.options.profile
     local export_timeout = tonumber(ctx.options.export_timeout) or 15
     local lease_timeout = tonumber(ctx.options.lease_timeout) or 30

--- a/hooks/mise_env.lua
+++ b/hooks/mise_env.lua
@@ -1,10 +1,32 @@
 local cmd = require("cmd")
 local json = require("json")
 
-local function get_config_files(fnox_bin)
+local function resolve_fnox_bin(fnox_bin)
+    local home = os.getenv("HOME") or os.getenv("USERPROFILE") or ""
+    local candidates = {
+        fnox_bin,
+        home .. "/.local/share/mise/installs/fnox/latest/fnox",
+        home .. "/.local/share/mise/shims/fnox",
+    }
+    for _, path in ipairs(candidates) do
+        local f = io.open(path, "r")
+        if f then
+            f:close()
+            return path
+        end
+    end
+    return fnox_bin
+end
+
+local function exec(command, opts)
     local ok, output = pcall(function()
-        return cmd.exec(fnox_bin .. " config-files")
+        return cmd.exec(command, opts)
     end)
+    return ok, output
+end
+
+local function get_config_files(fnox_bin, opts)
+    local ok, output = exec(fnox_bin .. " config-files", opts)
     if not ok then
         print("[fnox] warning: `" .. fnox_bin .. " config-files` failed: " .. tostring(output))
         return {}
@@ -20,10 +42,18 @@ local function get_config_files(fnox_bin)
 end
 
 function PLUGIN:MiseEnv(ctx)
-    local fnox_bin = ctx.options.fnox_bin or "fnox"
+    local fnox_bin = resolve_fnox_bin(ctx.options.fnox_bin or "fnox")
     local profile = ctx.options.profile
 
-    local config_files = get_config_files(fnox_bin)
+    -- ensure fnox's parent dir is on PATH for subprocesses
+    local fnox_dir = fnox_bin:match("(.+)/[^/]+$")
+    local exec_opts = {}
+    if fnox_dir then
+        local path = os.getenv("PATH") or ""
+        exec_opts = {env = {PATH = fnox_dir .. ":" .. path}}
+    end
+
+    local config_files = get_config_files(fnox_bin, exec_opts)
     if #config_files == 0 then
         return {cacheable = true, watch_files = {}, env = {}}
     end
@@ -37,9 +67,7 @@ function PLUGIN:MiseEnv(ctx)
 
     -- export secrets
     local export_cmd = fnox_bin .. " export --format json" .. profile_flag
-    local ok, output = pcall(function()
-        return cmd.exec(export_cmd)
-    end)
+    local ok, output = exec(export_cmd, exec_opts)
     if ok then
         local decode_ok, data = pcall(json.decode, output)
         if decode_ok then
@@ -55,9 +83,7 @@ function PLUGIN:MiseEnv(ctx)
 
     -- create leases and merge credentials
     local lease_cmd = fnox_bin .. " lease create --all --format json" .. profile_flag
-    local lok, loutput = pcall(function()
-        return cmd.exec(lease_cmd)
-    end)
+    local lok, loutput = exec(lease_cmd, exec_opts)
     if lok then
         local ldecode_ok, ldata = pcall(json.decode, loutput)
         if ldecode_ok then


### PR DESCRIPTION
adds lease credentials into the mise env exports, note the purpose of this is cachability so you don't have to hit the network before every command. it is up to the user to set an appropriate ttl on the cache.

## Summary
- Calls `fnox lease create --all --format json` alongside the existing secret export so ephemeral lease credentials (e.g. from Pulumi ESC) are merged into the mise environment
- Extracts the profile flag into a shared variable to avoid duplication
- Lease metadata keys (`backend`, `lease_id`) are filtered out; only string credential values are included

## Test plan
- [ ] Verify `fnox export` secrets still load correctly
- [ ] Verify `fnox lease create --all` credentials appear in the environment
- [ ] Confirm lease metadata keys are excluded from env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)